### PR TITLE
Added Google news scrapper

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -874,6 +874,26 @@ git = YouTube("https://www.youtube.com/watch?v=pBy1zgt0XPc")
 scrape = git.getDetails()
 ```
 
+## Google News
+
+### Scrape articles with title, descriptions, news source, date and link regarding a topic
+
+Create an instance of `GoogleNews` class.
+
+```python
+articles = GoogleNews("topic")
+```
+
+| Methods          | Details                                                                             |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| `.getArticles()` | Returns the articles with title, descriptions, news source, date and link in JSON format |
+
+**Example**
+
+```python
+art = GoogleNews("github")
+scrape = art.getArticles()
+```
 ## TimesJobs
 
 ```python

--- a/src/scrape_up/googleNews/__init__.py
+++ b/src/scrape_up/googleNews/__init__.py
@@ -1,0 +1,2 @@
+from scrape_up.googleNews.googleNews import GoogleNews
+__all__ = ["GoogleNews"]

--- a/src/scrape_up/googleNews/googleNews.py
+++ b/src/scrape_up/googleNews/googleNews.py
@@ -4,13 +4,36 @@ import json
 
 
 class GoogleNews:
+    """
+    Class - `GoogleNews`
+    Example:
+    ```
+    articles = GoogleNews(topic = "topic")
+    ```\n
+    Methods :\n
+    1. ``.getArticles() | Response - Articles with title, descriptions, news source, date and link.
+    """
     
-
     def __init__(self, topic):
         self.topic = topic
 
     def getArticles(self):
-        
+        """
+        Class - `GoogleNews`
+        Example:
+        ```
+        articles = GoogleNews("github")
+        articles.getArticles()
+        ```
+        Returns:
+        {
+            "title": Tile of the article
+            "description": Description of the article
+            "news_source": News Source of the Article
+            "date": Date the article was posted
+            "link": Link to the article
+        }
+        """
         url = (
             "https://www.google.com/search?q=" + self.topic + "&tbm=nws"
         )

--- a/src/scrape_up/googleNews/googleNews.py
+++ b/src/scrape_up/googleNews/googleNews.py
@@ -1,0 +1,64 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+
+
+class GoogleNews:
+    
+
+    def __init__(self, topic):
+        self.topic = topic
+
+    def getArticles(self):
+        
+        url = (
+            "https://www.google.com/search?q=" + self.topic + "&tbm=nws"
+        )
+        try:
+            res = requests.get(url)
+            soup = BeautifulSoup(res.text, "html.parser")
+
+            articles_data = {"articles": []}
+
+            articles = soup.find_all(
+                "a", jsname="ACyKwe"
+            )
+            for a in articles:
+                title = (
+                    a.find("div", class_="BNeawe vvjwJb AP7Wnd")
+                    .getText()
+                )
+                date = (
+                    a.find("span", class_="r0bn4c rQMQod")
+                    .getText()
+                )
+                desc = (
+                    a.find("div", class_="BNeawe s3v9rd AP7Wnd")
+                    .getText()
+                    .replace(date, '')
+                )
+                news_source = (
+                    a.find("div", class_="BNeawe UPmit AP7Wnd lRVwie")
+                    .getText()
+                )
+                link = (
+                    a["href"]
+                    .replace("/url?q=", '')
+                )
+                articles_data["articles"].append(
+                    {
+                        "title": title,
+                        "description": desc,
+                        "news_source": news_source,
+                        "date": date,
+                        "link": link,
+                    }
+                )
+            res_json = json.dumps(articles_data)
+            return res_json
+        except:
+            error_message = {
+                "message": "Can't fetch any articles from the topic provided."
+            }
+            ejson = json.dumps(error_message)
+            return ejson


### PR DESCRIPTION
## Description

> The googleNews scraper will retrieve the articles with title, descriptions, news source, date and link in JSON format for a given topic.

## Resolves: [#409]

## Checklist

> Before submitting this pull request, kindly verify that the ensuing checkpoints have been reached.

- [ ] Have you adhered to the repository's defined coding convention rules?
- [ ] Have you updated the 'documentation.md' file with the method/function documentation?
- [ ] Have you sent a message along with the result or response?
- [ ] Have you used the try-catch technique?
- [ ] Has the method/class been added to the documentation (md file)?

## Screenshots

![googleNews_validJSON](https://github.com/Clueless-Community/scrape-up/assets/42113027/05232d93-3f0e-49e1-a840-8a33165acccd)


---

I certify that I have carried out the relevant checks and provided the requisite screenshot for validation by submitting this pull request.
I appreciate your contribution.
